### PR TITLE
Stick to one connection instance

### DIFF
--- a/main.py
+++ b/main.py
@@ -106,7 +106,6 @@ def datasettings(file,method,line="",newvalue="",newkey=""):
 	s.write(slt); s.close(); return None
 
 
-Client = discord.Client()
 bot_prefix = datasettings(file="settings.txt",method="get",line="BOT_PREFIX")
 client = commands.Bot(command_prefix=bot_prefix)
 client.remove_command("help")


### PR DESCRIPTION
This PR removes `discord.Client`, as it's unnecessary. `commands.Bot` is a subclass of `discord.Client`, made to work with the command extension of discord.py, so having both is simply not a good practice. 
